### PR TITLE
API correction

### DIFF
--- a/build.py
+++ b/build.py
@@ -23,10 +23,12 @@ class Builder2:
         self.csv_data = csv_data
         self.json_data = json_data
         self.api_config = self.json_data.get("api")
-        if self.api_config is not None and self.arg_data.get("use_api") is True:
-            self.api_url = self.api_config.get("url") 
-            self.api_access_key = self.api_config.get("access_key")
-            self.api_secret_key = self.api_config.get("secret_key")
+        if self.arg_data.get("use_api") is True:
+            self.url_json = self.json_data.get("api_url")
+            self.url_arg = self.arg_data.get("api_url")
+            self.api_url = self.url_arg if self.url_arg is not None else self.url_json
+            self.api_access_key = self.arg_data.get("access_key")
+            self.api_secret_key = self.arg_data.get("secret_key")
             if self.api_url is not None and self.api_access_key is not None and self.api_secret_key is not None:
                 self.api = cybeats_API(api_url=self.api_url, access_key=self.api_access_key, secret_key=self.api_secret_key, package_type=arg_data.get("package_type"))
             else:

--- a/config_template.json
+++ b/config_template.json
@@ -1,4 +1,5 @@
 {
+  "api_url": null,
   "component_configuration": {
     "name": null,
     "version": null,

--- a/parse.py
+++ b/parse.py
@@ -42,6 +42,9 @@ class Parser:
         parser.add_argument("-ap", type=bool, required=False, help="add purl (optional)", default=False)
         parser.add_argument("-cnt", type=bool, required=False, help="csv no title (optional)", default=False)
         parser.add_argument("-api", type=bool, required=False, help="utilize cybeats api", default=False)
+        parser.add_argument("-url", type=str, required=False, help="cybeats api url", default=None)
+        parser.add_argument("-ak", type=str, required=False, help="cybeats access key", default=None)
+        parser.add_argument("-sk", type=str, required=False, help="cybeats secret key", default=None)
 
         args=parser.parse_args()
     
@@ -69,7 +72,9 @@ class Parser:
             parameters["add_purl"] = args.ap
             parameters["csv_no_title"] = args.cnt
             parameters["use_api"] = args.api
-
+            parameters["api_url"] = args.url
+            parameters["access_key"] = args.ak
+            parameters["secret_key"] = args.sk
 
 
         except Exception as err:


### PR DESCRIPTION
Allows of the csv2cdx tool to authenticate cybeats API calls using access and secret keys from command line arguments. API URLs can be input from either command  line argument (-url), or in the config file (api_url).